### PR TITLE
fix: validate WeCom webhook business errors

### DIFF
--- a/xnotify/wework.go
+++ b/xnotify/wework.go
@@ -2,13 +2,14 @@ package xnotify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
 	"github.com/daodao97/xgo/xrequest"
 )
 
-const wecomWebhookURL = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key="
+var wecomWebhookURL = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key="
 const (
 	wecomMsgTypeText       = MessageTypeText
 	wecomMsgTypeMarkdown   = MessageTypeMarkdown
@@ -16,6 +17,11 @@ const (
 )
 
 type weworkSender struct{}
+
+type wecomResponse struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+}
 
 func SendWeComText(ctx context.Context, botID, content string, mentionedMobiles []string) error {
 	return sendWeCom(ctx, botID, buildWeComTextPayload(content, mentionedMobiles))
@@ -67,8 +73,20 @@ func sendWeCom(ctx context.Context, botID string, data map[string]any) error {
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode() >= 400 {
-		return fmt.Errorf("wecom send failed, status: %d", resp.StatusCode())
+	defer resp.Close()
+	return parseWeComResponse(resp.StatusCode(), resp.Bytes())
+}
+
+func parseWeComResponse(statusCode int, body []byte) error {
+	if statusCode >= 400 {
+		return fmt.Errorf("wecom send failed, status: %d", statusCode)
+	}
+	var result wecomResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return fmt.Errorf("wecom send failed, decode response: %w", err)
+	}
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wecom send failed, errcode: %d, errmsg: %s", result.ErrCode, result.ErrMsg)
 	}
 	return nil
 }

--- a/xnotify/wework_test.go
+++ b/xnotify/wework_test.go
@@ -1,6 +1,8 @@
 package xnotify
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestBuildWeComTextPayload(t *testing.T) {
 	payload := buildWeComTextPayload("hello", []string{"13800001111", "@all"})
@@ -61,5 +63,15 @@ func TestBuildWeComMarkdownV2Payload(t *testing.T) {
 	}
 	if markdownV2["content"] != "# title" {
 		t.Fatalf("markdown_v2 content mismatch, got %v", markdownV2["content"])
+	}
+}
+
+func TestParseWeComResponseReturnsBusinessError(t *testing.T) {
+	err := parseWeComResponse(200, []byte(`{"errcode":93000,"errmsg":"invalid webhook key"}`))
+	if err == nil {
+		t.Fatal("expected business error, got nil")
+	}
+	if got := err.Error(); got != "wecom send failed, errcode: 93000, errmsg: invalid webhook key" {
+		t.Fatalf("unexpected error: %s", got)
 	}
 }


### PR DESCRIPTION
Fixes DAO-2.

- parse WeCom webhook JSON responses instead of trusting HTTP 200 alone
- return business errcode/errmsg to callers
- add a regression test for HTTP 200 with non-zero errcode