### PR TITLE
fix: use timeout context for server shutdown

### DIFF
--- a/xhttp/start_server.go
+++ b/xhttp/start_server.go
@@ -60,14 +60,19 @@ func StartServer(handler http.Handler, addr string, shutdownTimeout time.Duratio
 	<-upg.Exit()
 	xlog.Info("shutting down...")
 
-	// Make sure to set a deadline on exiting the process
-	// after upg.Exit() is closed. No new upgrades can be
-	// performed if the parent doesn't exit.
-	time.AfterFunc(shutdownTimeout, func() {
-		log.Println("Graceful shutdown timed out")
-		os.Exit(1)
-	})
+	shutdownServer(shutdownTimeout, server.Shutdown, os.Exit)
+}
 
-	// Wait for connections to drain.
-	server.Shutdown(context.Background())
+func shutdownServer(shutdownTimeout time.Duration, shutdownFn func(context.Context) error, exitFn func(int)) {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := shutdownFn(ctx); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Println("Graceful shutdown timed out")
+			exitFn(1)
+			return
+		}
+		log.Println("Graceful shutdown failed:", err)
+	}
 }

--- a/xhttp/start_server_test.go
+++ b/xhttp/start_server_test.go
@@ -1,0 +1,57 @@
+package xhttp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestShutdownServerUsesTimeoutContext(t *testing.T) {
+	timeout := 50 * time.Millisecond
+	var deadline time.Time
+
+	shutdownServer(timeout, func(ctx context.Context) error {
+		var ok bool
+		deadline, ok = ctx.Deadline()
+		if !ok {
+			t.Fatal("expected shutdown context to have deadline")
+		}
+		return nil
+	}, func(int) {
+		t.Fatal("did not expect exit on successful shutdown")
+	})
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > timeout {
+		t.Fatalf("unexpected shutdown deadline window: %v", remaining)
+	}
+}
+
+func TestShutdownServerExitsOnTimeout(t *testing.T) {
+	exitCode := 0
+
+	shutdownServer(time.Millisecond, func(ctx context.Context) error {
+		return context.DeadlineExceeded
+	}, func(code int) {
+		exitCode = code
+	})
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+}
+
+func TestShutdownServerDoesNotExitOnNonTimeoutError(t *testing.T) {
+	exitCode := 0
+
+	shutdownServer(time.Millisecond, func(ctx context.Context) error {
+		return errors.New("shutdown failed")
+	}, func(code int) {
+		exitCode = code
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected no exit, got code %d", exitCode)
+	}
+}


### PR DESCRIPTION
Fixes DAO-4.

- run graceful shutdown with context.WithTimeout instead of context.Background
- handle and log Shutdown errors explicitly
- add unit tests covering timeout and non-timeout shutdown paths