### PR TITLE
fix: coordinate app server startup readiness

### DIFF
--- a/xapp/http.go
+++ b/xapp/http.go
@@ -2,7 +2,10 @@ package xapp
 
 import (
 	"context"
+	"errors"
+	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/daodao97/xgo/xlog"
@@ -17,7 +20,9 @@ func NewHttp(addr string, handler func() http.Handler) NewServer {
 }
 
 type HTTPServer struct {
-	server *http.Server
+	server      *http.Server
+	started     chan struct{}
+	startedOnce sync.Once
 }
 
 func NewHTTPServer(addr string, handler func() http.Handler) *HTTPServer {
@@ -32,12 +37,28 @@ func NewHTTPServer(addr string, handler func() http.Handler) *HTTPServer {
 			Addr:    addr,
 			Handler: handler(),
 		},
+		started: make(chan struct{}),
 	}
 }
 
 func (s *HTTPServer) Start() error {
 	xlog.Debug("Starting HTTP server on", xlog.String("port", s.server.Addr))
-	return s.server.ListenAndServe()
+	ln, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.startedOnce.Do(func() {
+		close(s.started)
+	})
+	err = s.server.Serve(ln)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func (s *HTTPServer) Started() <-chan struct{} {
+	return s.started
 }
 
 func (s *HTTPServer) Stop() {

--- a/xapp/xapp.go
+++ b/xapp/xapp.go
@@ -6,10 +6,16 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/daodao97/xgo/xlog"
 	"github.com/jessevdk/go-flags"
+)
+
+var (
+	signalNotify = signal.Notify
+	signalStop   = signal.Stop
 )
 
 type Startup func() error
@@ -25,6 +31,10 @@ type BeforeStart func()
 type Server interface {
 	Start() error
 	Stop()
+}
+
+type readinessServer interface {
+	Started() <-chan struct{}
 }
 
 var Args struct {
@@ -86,32 +96,55 @@ func (a *App) Run() error {
 	// 启动所有 Server
 	errChan := make(chan error, len(a.servers))
 	var wg sync.WaitGroup
+	var startupFailed atomic.Bool
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var servers []Server
+	servers := make([]Server, 0, len(a.servers))
+	readyChans := make([]<-chan struct{}, 0, len(a.servers))
+	for _, newServer := range a.servers {
+		server := newServer()
+		servers = append(servers, server)
 
-	for _, server := range a.servers {
+		ready := make(chan struct{})
+		var readyOnce sync.Once
+		closeReady := func() {
+			readyOnce.Do(func() {
+				close(ready)
+			})
+		}
+		if startedServer, ok := server.(readinessServer); ok {
+			go func(started <-chan struct{}) {
+				<-started
+				closeReady()
+			}(startedServer.Started())
+		}
+		readyChans = append(readyChans, ready)
+
 		wg.Add(1)
-		go func(s NewServer) {
+		go func(s Server, closeReady func(), readyBySignal bool) {
 			defer wg.Done()
-			_s := s()
-			servers = append(servers, _s)
-			if err := _s.Start(); err != nil {
+			if !readyBySignal {
+				closeReady()
+			}
+			if err := s.Start(); err != nil {
+				startupFailed.Store(true)
+				closeReady()
 				errChan <- err
 				cancel()
 			}
-		}(server)
+		}(server, closeReady, isReadyByStartCall(server))
 	}
 
-	if a.afterStarted != nil {
+	if a.afterStarted != nil && waitForServersReady(ctx, readyChans) && !startupFailed.Load() {
 		a.afterStarted()
 	}
 
 	// 处理信号
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signalNotify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signalStop(sigChan)
 
 	var signalCount int
 	shutdownChan := make(chan struct{})
@@ -142,6 +175,11 @@ func (a *App) Run() error {
 	case <-shutdownChan:
 		xlog.Debug("Starting graceful shutdown...")
 	case <-ctx.Done():
+		select {
+		case err := <-errChan:
+			return fmt.Errorf("server error: %w", err)
+		default:
+		}
 		xlog.Warn("Context cancelled")
 	}
 
@@ -154,6 +192,22 @@ func (a *App) Run() error {
 	wg.Wait()
 	xlog.Debug("All servers stopped")
 	return nil
+}
+
+func isReadyByStartCall(server Server) bool {
+	_, ok := server.(readinessServer)
+	return ok
+}
+
+func waitForServersReady(ctx context.Context, readyChans []<-chan struct{}) bool {
+	for _, ready := range readyChans {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ready:
+		}
+	}
+	return true
 }
 
 func ParserFlags(dest any) {

--- a/xapp/xapp_test.go
+++ b/xapp/xapp_test.go
@@ -1,0 +1,143 @@
+package xapp
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+type readyTestServer struct {
+	started    chan struct{}
+	run        chan struct{}
+	stopOnce   sync.Once
+	stopCalled chan struct{}
+}
+
+func newReadyTestServer() *readyTestServer {
+	return &readyTestServer{
+		started:    make(chan struct{}),
+		run:        make(chan struct{}),
+		stopCalled: make(chan struct{}),
+	}
+}
+
+func (s *readyTestServer) Start() error {
+	<-s.run
+	return nil
+}
+
+func (s *readyTestServer) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.run)
+		close(s.stopCalled)
+	})
+}
+
+func (s *readyTestServer) Started() <-chan struct{} {
+	return s.started
+}
+
+type errorReadyServer struct{}
+
+func (errorReadyServer) Start() error {
+	return errors.New("boom")
+}
+
+func (errorReadyServer) Stop() {}
+
+func (errorReadyServer) Started() <-chan struct{} {
+	return make(chan struct{})
+}
+
+func TestAppRunWaitsForReadyServersBeforeAfterStarted(t *testing.T) {
+	s1 := newReadyTestServer()
+	s2 := newReadyTestServer()
+	afterStarted := make(chan struct{})
+	runDone := make(chan error, 1)
+	injectedSignals := make(chan os.Signal, 1)
+
+	oldNotify := signalNotify
+	oldStop := signalStop
+	signalNotify = func(c chan<- os.Signal, _ ...os.Signal) {
+		go func() {
+			sig := <-injectedSignals
+			c <- sig
+		}()
+	}
+	signalStop = func(chan<- os.Signal) {}
+	defer func() {
+		signalNotify = oldNotify
+		signalStop = oldStop
+	}()
+
+	app := NewApp().
+		AddServer(func() Server { return s1 }, func() Server { return s2 }).
+		AfterStarted(func() {
+			close(afterStarted)
+		})
+
+	go func() {
+		runDone <- app.Run()
+	}()
+
+	select {
+	case <-afterStarted:
+		t.Fatal("afterStarted called before servers became ready")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(s1.started)
+	close(s2.started)
+
+	select {
+	case <-afterStarted:
+	case <-time.After(time.Second):
+		t.Fatal("afterStarted was not called after readiness signals")
+	}
+
+	injectedSignals <- os.Interrupt
+
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after shutdown signal")
+	}
+
+	select {
+	case <-s1.stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("server 1 was not stopped")
+	}
+
+	select {
+	case <-s2.stopCalled:
+	case <-time.After(time.Second):
+		t.Fatal("server 2 was not stopped")
+	}
+}
+
+func TestAppRunSkipsAfterStartedWhenReadyServerFails(t *testing.T) {
+	called := false
+
+	err := NewApp().
+		AddServer(func() Server { return errorReadyServer{} }).
+		AfterStarted(func() {
+			called = true
+		}).
+		Run()
+
+	if err == nil {
+		t.Fatal("expected startup error")
+	}
+	if err.Error() != "server error: boom" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Fatal("afterStarted should not run when startup fails")
+	}
+}


### PR DESCRIPTION
Fixes DAO-3.

- build the server list before launching goroutines to avoid concurrent append races
- wait for readiness-aware servers before running afterStarted
- add tests covering readiness ordering, startup failure, and graceful shutdown