### PR TITLE
fix: manage config watcher lifecycle

### DIFF
--- a/xapp/conf.go
+++ b/xapp/conf.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/daodao97/xgo/xenv"
@@ -22,6 +23,16 @@ var confDir = []string{
 	"../",
 }
 
+type confWatcherState struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+var (
+	confWatcherMu    sync.Mutex
+	currentConfWatch *confWatcherState
+)
+
 func SetConfDir(dir ...string) {
 	confDir = append(confDir, dir...)
 }
@@ -37,7 +48,8 @@ func getConfFile() []string {
 	return files
 }
 
-func fileConf(dest any, files ...string) error {
+func fileConf(dest any, files ...string) ([]string, error) {
+	var loadedFiles []string
 	for _, dir := range confDir {
 		for _, file := range files {
 			// 检查文件是否存在
@@ -47,30 +59,31 @@ func fileConf(dest any, files ...string) error {
 
 			absFile, err := filepath.Abs(filepath.Join(dir, file))
 			if err != nil {
-				return fmt.Errorf("获取绝对路径失败 %s: %v", file, err)
+				return nil, fmt.Errorf("获取绝对路径失败 %s: %v", file, err)
 			}
 
 			// 读取文件内容
 			data, err := os.ReadFile(absFile)
 			if err != nil {
-				return fmt.Errorf("读取配置文件失败 %s: %v", file, err)
+				return nil, fmt.Errorf("读取配置文件失败 %s: %v", file, err)
 			}
 
 			// 解析 YAML 到目标结构体
 			if err := yaml.Unmarshal(data, dest); err != nil {
-				return fmt.Errorf("解析配置文件失败 %s: %v", file, err)
+				return nil, fmt.Errorf("解析配置文件失败 %s: %v", file, err)
 			}
 
 			xlog.Info("load config", xlog.String("file", file))
+			loadedFiles = append(loadedFiles, absFile)
 		}
 	}
 
 	// 处理环境变量替换
 	if err := env.Parse(dest); err != nil {
-		return fmt.Errorf("处理环境变量失败: %v", err)
+		return nil, fmt.Errorf("处理环境变量失败: %v", err)
 	}
 
-	return nil
+	return uniqueStrings(loadedFiles), nil
 }
 
 // InitConf 初始化配置
@@ -79,12 +92,13 @@ func InitConf(dest any) error {
 		return fmt.Errorf("配置目标必须是结构体指针类型")
 	}
 	confFiles := getConfFile()
-	err := fileConf(dest, confFiles...)
+	loadedFiles, err := fileConf(dest, confFiles...)
 	if err != nil {
 		return err
 	}
 
 	if !xenv.IsDev() {
+		closeConfWatcher()
 		return nil
 	}
 
@@ -95,9 +109,25 @@ func InitConf(dest any) error {
 		return fmt.Errorf("创建监听器失败: %v", err)
 	}
 
-	xutil.Go(context.Background(), func() {
+	for _, file := range loadedFiles {
+		if err := watcher.Add(file); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			_ = watcher.Close()
+			return fmt.Errorf("添加文件监听失败 %s: %v", file, err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	xutil.Go(ctx, func() {
+		defer close(done)
+		defer watcher.Close()
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event, ok := <-watcher.Events:
 				if !ok {
 					xlog.Error("监听器退出")
@@ -105,7 +135,7 @@ func InitConf(dest any) error {
 				}
 				// 如果是写入或创建事件，重新加载配置
 				if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
-					if err := fileConf(dest); err != nil {
+					if _, err := fileConf(dest, confFiles...); err != nil {
 						xlog.Error("重新加载配置失败", xlog.Err(err))
 					} else {
 						xlog.Info("配置已重新加载", xlog.String("file", event.Name))
@@ -119,16 +149,40 @@ func InitConf(dest any) error {
 			}
 		}
 	})
-
-	for _, file := range confFiles {
-		if err := watcher.Add(file); err != nil {
-			// 如果文件不存在，跳过
-			if os.IsNotExist(err) {
-				continue
-			}
-			return fmt.Errorf("添加文件监听失败 %s: %v", file, err)
-		}
-	}
+	replaceConfWatcher(&confWatcherState{cancel: cancel, done: done})
 
 	return nil
+}
+
+func CloseConfWatcher() {
+	closeConfWatcher()
+}
+
+func closeConfWatcher() {
+	replaceConfWatcher(nil)
+}
+
+func replaceConfWatcher(next *confWatcherState) {
+	confWatcherMu.Lock()
+	prev := currentConfWatch
+	currentConfWatch = next
+	confWatcherMu.Unlock()
+
+	if prev != nil {
+		prev.cancel()
+		<-prev.done
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }

--- a/xapp/conf_test.go
+++ b/xapp/conf_test.go
@@ -1,32 +1,104 @@
 package xapp
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/daodao97/xgo/xredis"
+	"github.com/daodao97/xgo/xenv"
 )
 
-func TestInitConf(t *testing.T) {
+func TestInitConfReloadsFilesFromResolvedPaths(t *testing.T) {
+	tempDir := t.TempDir()
+	writeFile(t, filepath.Join(tempDir, "conf.yaml"), "bind: base\n")
+	writeFile(t, filepath.Join(tempDir, "conf.dev.yaml"), "bind: dev\n")
+
+	originalConfDir := confDir
+	originalAppEnv := Args.AppEnv
+	originalXEnv := xenv.AppEnv
+	confDir = []string{tempDir}
+	Args.AppEnv = "dev"
+	xenv.AppEnv = "dev"
+	defer func() {
+		confDir = originalConfDir
+		Args.AppEnv = originalAppEnv
+		xenv.AppEnv = originalXEnv
+		CloseConfWatcher()
+	}()
+
 	var conf struct {
-		Bind  string           `yaml:"bind" env:"BIND"`
-		Redis []xredis.Options `yaml:"redis" envPrefix:"REDIS"`
+		Bind string `yaml:"bind"`
 	}
-	os.Setenv("BIND", "127.0.0.1:8080")
-	os.Setenv("REDIS_0_NAME", "test")
-	os.Setenv("REDIS_0_ADDR", "127.0.0.1:6379")
-	os.Setenv("REDIS_0_PASSWORD", "123456")
-	os.Setenv("REDIS_0_DB", "0")
 
-	InitConf(&conf)
-
-	// env.Parse(&conf)
-
-	fmt.Println(conf)
-	for {
-		time.Sleep(time.Second)
-		fmt.Println(conf)
+	if err := InitConf(&conf); err != nil {
+		t.Fatalf("InitConf failed: %v", err)
 	}
+	if conf.Bind != "dev" {
+		t.Fatalf("expected initial dev config, got %q", conf.Bind)
+	}
+
+	writeFile(t, filepath.Join(tempDir, "conf.dev.yaml"), "bind: reloaded\n")
+	waitFor(t, time.Second, func() bool {
+		return conf.Bind == "reloaded"
+	})
+}
+
+func TestInitConfClosesPreviousWatcherOnReinit(t *testing.T) {
+	tempDir := t.TempDir()
+	writeFile(t, filepath.Join(tempDir, "conf.yaml"), "bind: first\n")
+
+	originalConfDir := confDir
+	originalAppEnv := Args.AppEnv
+	originalXEnv := xenv.AppEnv
+	confDir = []string{tempDir}
+	Args.AppEnv = "dev"
+	xenv.AppEnv = "dev"
+	defer func() {
+		confDir = originalConfDir
+		Args.AppEnv = originalAppEnv
+		xenv.AppEnv = originalXEnv
+		CloseConfWatcher()
+	}()
+
+	var first struct {
+		Bind string `yaml:"bind"`
+	}
+	if err := InitConf(&first); err != nil {
+		t.Fatalf("first InitConf failed: %v", err)
+	}
+
+	var second struct {
+		Bind string `yaml:"bind"`
+	}
+	if err := InitConf(&second); err != nil {
+		t.Fatalf("second InitConf failed: %v", err)
+	}
+
+	writeFile(t, filepath.Join(tempDir, "conf.yaml"), "bind: second\n")
+	waitFor(t, time.Second, func() bool {
+		return second.Bind == "second"
+	})
+	if first.Bind == "second" {
+		t.Fatal("expected previous watcher to stop reloading old config target")
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
 }


### PR DESCRIPTION
Fixes DAO-5.

- watch the resolved config file paths instead of bare filenames
- reuse the same config file list during reload and expose watcher cleanup
- add tests for reloads from custom config directories and watcher replacement