### PR TITLE
xlog: add context attribute extractors for automatic logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,22 @@ The repository structure:
 - Trace ID integration via `xtrace`
 - Helper functions: `xlog.Debug()`, `xlog.Info()`, `xlog.Warn()`, `xlog.Error()`
 - Attribute helpers: `xlog.Any()`, `xlog.Err()`
+- Context attr extractors: `xlog.RegisterCtxExtractor(func(ctx) []slog.Attr)` lets user projects auto-inject attrs from `ctx` into any `XxxCtx` log call. Built-in defaults handle `request_id` (string ctx key) and `traceid` (via `xtrace.FromTraceId`). Typical usage:
+
+  ```go
+  func init() {
+      xlog.RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+          u, ok := auth.UserFromContext(ctx)
+          if !ok { return nil }
+          return []slog.Attr{
+              xlog.String("user_id", u.ID),
+              xlog.String("tenant", u.Tenant),
+          }
+      })
+  }
+  ```
+
+  Registration is lock-free (`atomic.Pointer` copy-on-write); safe to call from `init()` or at runtime.
 
 ### Database Layer (xdb)
 - Model-based ORM with chainable query builder

--- a/xlog/ctx_extractor_test.go
+++ b/xlog/ctx_extractor_test.go
@@ -1,0 +1,171 @@
+package xlog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/daodao97/xgo/xtrace"
+)
+
+// snapshotExtractors 在测试开始时保存当前注册表，测试结束后恢复。
+// 用于隔离测试间的全局状态污染。
+func snapshotExtractors(t *testing.T) {
+	t.Helper()
+	saved := ctxExtractors.Load()
+	t.Cleanup(func() {
+		ctxExtractors.Store(saved)
+	})
+}
+
+func TestRegisterCtxExtractor_appendsToRegistry(t *testing.T) {
+	snapshotExtractors(t)
+	// 清空，便于断言长度
+	ctxExtractors.Store(nil)
+
+	ex1 := func(ctx context.Context) []slog.Attr { return nil }
+	ex2 := func(ctx context.Context) []slog.Attr { return nil }
+
+	RegisterCtxExtractor(ex1)
+	p := ctxExtractors.Load()
+	if p == nil || len(*p) != 1 {
+		t.Fatalf("expected len 1 after first register, got %v", p)
+	}
+
+	RegisterCtxExtractor(ex2)
+	p = ctxExtractors.Load()
+	if p == nil || len(*p) != 2 {
+		t.Fatalf("expected len 2 after second register, got %v", p)
+	}
+}
+
+func TestRegisterCtxExtractor_ignoresNil(t *testing.T) {
+	snapshotExtractors(t)
+	ctxExtractors.Store(nil)
+
+	RegisterCtxExtractor(nil)
+	p := ctxExtractors.Load()
+	if p != nil && len(*p) != 0 {
+		t.Fatalf("expected empty/nil registry after registering nil, got %v", p)
+	}
+}
+
+func TestWithCtxAttrs_nilCtxReturnsArgsUnchanged(t *testing.T) {
+	snapshotExtractors(t)
+	ctxExtractors.Store(nil)
+
+	args := []any{slog.String("k", "v")}
+	var nilCtx context.Context // intentional: verify withCtxAttrs is nil-ctx safe
+	got := withCtxAttrs(nilCtx, args...)
+	if len(got) != 1 {
+		t.Fatalf("expected len 1, got %d", len(got))
+	}
+}
+
+func TestWithCtxAttrs_appliesAllExtractors(t *testing.T) {
+	snapshotExtractors(t)
+	ctxExtractors.Store(nil)
+
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+		return []slog.Attr{slog.String("from_ex1", "v1")}
+	})
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+		return []slog.Attr{
+			slog.String("from_ex2_a", "va"),
+			slog.String("from_ex2_b", "vb"),
+		}
+	})
+
+	got := withCtxAttrs(context.Background(), slog.String("user", "manual"))
+	if len(got) != 4 {
+		t.Fatalf("expected 4 args (1 manual + 1 + 2), got %d: %#v", len(got), got)
+	}
+}
+
+func TestWithCtxAttrs_nilReturnSkipped(t *testing.T) {
+	snapshotExtractors(t)
+	ctxExtractors.Store(nil)
+
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr { return nil })
+
+	got := withCtxAttrs(context.Background(), slog.String("k", "v"))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 arg (nil extractor adds nothing), got %d", len(got))
+	}
+}
+
+// captureCtxLog 用 JSON handler 捕获一次 InfoCtx 输出，返回解析后的 map。
+func captureCtxLog(t *testing.T, ctx context.Context, msg string, args ...any) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := GetLogger()
+	t.Cleanup(func() { SetLogger(prev) })
+	SetLogger(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+
+	InfoCtx(ctx, msg, args...)
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &out); err != nil {
+		t.Fatalf("parse log output: %v\nraw: %s", err, buf.String())
+	}
+	return out
+}
+
+func TestDefaultExtractor_RequestId(t *testing.T) {
+	snapshotExtractors(t)
+	// 不清空，依赖 init() 注册的默认 extractor
+
+	ctx := context.WithValue(context.Background(), "request_id", "rid-123")
+	out := captureCtxLog(t, ctx, "hello")
+
+	if out["request_id"] != "rid-123" {
+		t.Errorf("expected request_id=rid-123, got %v", out["request_id"])
+	}
+}
+
+func TestDefaultExtractor_RequestIdMissingDoesNotPanic(t *testing.T) {
+	snapshotExtractors(t)
+	ctx := context.Background()
+	out := captureCtxLog(t, ctx, "hello")
+	if _, ok := out["request_id"]; ok {
+		t.Errorf("expected no request_id field when ctx has none, got %v", out["request_id"])
+	}
+}
+
+func TestDefaultExtractor_TraceId(t *testing.T) {
+	snapshotExtractors(t)
+
+	// xtrace.SetTraceId 是写入 trace id 的官方入口（xtrace/xtrace.go:80）。
+	ctx := xtrace.SetTraceId(context.Background(), "trace-abc")
+	out := captureCtxLog(t, ctx, "hello")
+
+	if out["traceid"] != "trace-abc" {
+		t.Errorf("expected traceid=trace-abc, got %v", out["traceid"])
+	}
+}
+
+func TestInfoCtx_AppliesCustomExtractor(t *testing.T) {
+	snapshotExtractors(t)
+
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+		if v, ok := ctx.Value("user_id").(string); ok {
+			return []slog.Attr{slog.String("user_id", v)}
+		}
+		return nil
+	})
+
+	ctx := context.WithValue(context.Background(), "user_id", "u-42")
+	out := captureCtxLog(t, ctx, "hello", slog.String("order_id", "o-1"))
+
+	if out["user_id"] != "u-42" {
+		t.Errorf("expected user_id=u-42, got %v", out["user_id"])
+	}
+	if out["order_id"] != "o-1" {
+		t.Errorf("expected manual order_id=o-1 preserved, got %v", out["order_id"])
+	}
+}

--- a/xlog/log.go
+++ b/xlog/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"sync/atomic"
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -12,6 +13,22 @@ import (
 
 func init() {
 	SetLogger(StdoutTextPretty())
+
+	// 默认 extractor：request_id（从 ctx string-key 读，无则跳过）
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+		if v, ok := ctx.Value("request_id").(string); ok && v != "" {
+			return []slog.Attr{slog.String("request_id", v)}
+		}
+		return nil
+	})
+
+	// 默认 extractor：traceid（xtrace 包内部维护 ctx key）
+	RegisterCtxExtractor(func(ctx context.Context) []slog.Attr {
+		if tid := xtrace.FromTraceId(ctx); tid != "" {
+			return []slog.Attr{slog.String("traceid", tid)}
+		}
+		return nil
+	})
 }
 
 var opts = slog.HandlerOptions{
@@ -21,6 +38,51 @@ var opts = slog.HandlerOptions{
 }
 
 var logger = StdoutTextPretty()
+
+// CtxExtractor 从 ctx 中提取一组 slog.Attr。无值时返回 nil（或空切片）。
+// 通过 RegisterCtxExtractor 注册后，所有带 ctx 的日志调用都会自动应用。
+type CtxExtractor func(ctx context.Context) []slog.Attr
+
+var ctxExtractors atomic.Pointer[[]CtxExtractor]
+
+// RegisterCtxExtractor 注册一个 Context Attr 提取器。
+// 通常在 init() 或 main() 早期调用。运行时调用也安全（lock-free copy-on-write）。
+// 传入 nil 会被忽略。
+func RegisterCtxExtractor(ex CtxExtractor) {
+	if ex == nil {
+		return
+	}
+	for {
+		old := ctxExtractors.Load()
+		var oldSlice []CtxExtractor
+		if old != nil {
+			oldSlice = *old
+		}
+		newSlice := make([]CtxExtractor, 0, len(oldSlice)+1)
+		newSlice = append(newSlice, oldSlice...)
+		newSlice = append(newSlice, ex)
+		if ctxExtractors.CompareAndSwap(old, &newSlice) {
+			return
+		}
+	}
+}
+
+// withCtxAttrs 遍历所有已注册的 extractor，把它们返回的 attr 追加到 args。
+func withCtxAttrs(ctx context.Context, args ...any) []any {
+	if ctx == nil {
+		return args
+	}
+	p := ctxExtractors.Load()
+	if p == nil {
+		return args
+	}
+	for _, ex := range *p {
+		for _, attr := range ex(ctx) {
+			args = append(args, attr)
+		}
+	}
+	return args
+}
 
 func SetLogger(l *slog.Logger) {
 	logger = l
@@ -78,33 +140,20 @@ func Warn(msg string, args ...any) {
 	logger.Warn(msg, args...)
 }
 
-func withTriceId(ctx context.Context, args ...any) []any {
-	if ctx == nil {
-		return args
-	}
-	if requestId := ctx.Value("request_id"); requestId != nil {
-		args = append(args, String("request_id", requestId.(string)))
-	}
-	if traceId := xtrace.FromTraceId(ctx); traceId != "" {
-		args = append(args, String("traceid", traceId))
-	}
-	return args
-}
-
 func DebugCtx(ctx context.Context, msg string, args ...any) {
-	logger.DebugContext(ctx, msg, withTriceId(ctx, args...)...)
+	logger.DebugContext(ctx, msg, withCtxAttrs(ctx, args...)...)
 }
 
 func InfoCtx(ctx context.Context, msg string, args ...any) {
-	logger.InfoContext(ctx, msg, withTriceId(ctx, args...)...)
+	logger.InfoContext(ctx, msg, withCtxAttrs(ctx, args...)...)
 }
 
 func ErrorCtx(ctx context.Context, msg string, args ...any) {
-	logger.ErrorContext(ctx, msg, withTriceId(ctx, args...)...)
+	logger.ErrorContext(ctx, msg, withCtxAttrs(ctx, args...)...)
 }
 
 func WarnCtx(ctx context.Context, msg string, args ...any) {
-	logger.WarnContext(ctx, msg, withTriceId(ctx, args...)...)
+	logger.WarnContext(ctx, msg, withCtxAttrs(ctx, args...)...)
 }
 
 func err(err error) slog.Attr {


### PR DESCRIPTION
`xlog` 中允许用户项目注册自己项目内部的 Context Log Attribute 。

在 init 周期内注册，打 Log 时如果 ctx 内有对应的值，自动加到 Attr 中，简化用户代码。