### PR TITLE
xdb: fix context handling in Ctx method to avoid race conditions

### DIFF
--- a/xdb/model.go
+++ b/xdb/model.go
@@ -166,8 +166,9 @@ func (m *model) Tx(tx *sql.Tx) Model {
 }
 
 func (m *model) Ctx(ctx context.Context) Model {
-	m.ctx = ctx
-	return m
+	newM := *m
+	newM.ctx = ctx
+	return &newM
 }
 
 func (m *model) PrimaryKey() string {


### PR DESCRIPTION
Model.Ctx() 目前的实现会造成竞态，会导致 log 中 trace_id 串杂的问题