### PR TITLE
xdb: InsertIgnore 返回 RowsAffected 而非 LastInsertId

### DIFF
--- a/xdb/README.md
+++ b/xdb/README.md
@@ -144,10 +144,15 @@ affected, err := m.InsertOrUpdate(xdb.Record{
 
 ```go
 // 所有数据库统一 API
-lastId, err := m.InsertIgnore(xdb.Record{
+// 返回受影响行数：1 表示插入成功，0 表示因唯一键冲突被忽略。
+// 用 RowsAffected 而非 LastInsertId，主键非自增（如应用生成的 xid）时也能正确判定。
+affected, err := m.InsertIgnore(xdb.Record{
     "id":   1,
     "name": "Alice",
 })
+if affected > 0 {
+    // 新插入
+}
 
 // MySQL 生成:
 // INSERT IGNORE INTO users (id, name) VALUES (?, ?)

--- a/xdb/model.go
+++ b/xdb/model.go
@@ -26,7 +26,10 @@ type Model interface {
 	Inserts(records []Record) (lastId int64, err error)
 	Update(record Record, opt ...Option) (ok bool, err error)
 	InsertOrUpdate(record Record, updateFields ...string) (affected int64, err error)
-	InsertIgnore(record Record) (lastId int64, err error)
+	// InsertIgnore 插入一条记录，若与唯一键冲突则忽略。
+	// 返回受影响行数：1 表示插入成功，0 表示因冲突被忽略。
+	// 用 RowsAffected 而非 LastInsertId，以便在主键非自增（如应用生成的 xid）时也能正确判定。
+	InsertIgnore(record Record) (affected int64, err error)
 	Delete(opt ...Option) (ok bool, err error)
 	Exec(query string, args ...any) (sql.Result, error)
 	Query(query string, args ...any) (*sql.Rows, error)
@@ -701,13 +704,13 @@ func (m *model) InsertOrUpdate(record Record, updateFields ...string) (affected 
 	return affected, nil
 }
 
-func (m *model) InsertIgnore(record Record) (lastId int64, err error) {
+func (m *model) InsertIgnore(record Record) (affected int64, err error) {
 	if m.err != nil {
 		return 0, m.err
 	}
 
 	var kv []any
-	defer dbLog(m.ctx, "InsertOrUpdate", time.Now(), &err, &kv)
+	defer dbLog(m.ctx, "InsertIgnore", time.Now(), &err, &kv)
 
 	if len(record) == 0 {
 		return 0, errors.New("空记录无法插入")
@@ -748,7 +751,7 @@ func (m *model) InsertIgnore(record Record) (lastId int64, err error) {
 		return 0, err
 	}
 
-	affected, err := result.LastInsertId()
+	affected, err = result.RowsAffected()
 	if err != nil {
 		return 0, err
 	}

--- a/xdb/model_insert_ignore_test.go
+++ b/xdb/model_insert_ignore_test.go
@@ -1,0 +1,96 @@
+package xdb
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeInsertIgnore* below implement a minimal database/sql driver so that the
+// return value of InsertIgnore can be exercised deterministically, without a
+// live database. It simulates a table whose primary key is application
+// generated (e.g. an xid string) rather than auto-increment: LastInsertId is
+// always 0, while RowsAffected reflects whether a row was actually inserted.
+// SQLite cannot reproduce this because every row gets an implicit rowid, so a
+// purpose-built fake is the only server-free way to pin down the behaviour.
+
+const fakeInsertIgnoreDriverName = "fake_insert_ignore_driver"
+
+// fakeNextLastInsertID / fakeNextRowsAffected control what the next Exec
+// reports. Tests set them before each InsertIgnore call.
+var (
+	fakeNextLastInsertID int64
+	fakeNextRowsAffected int64
+)
+
+type fakeInsertIgnoreResult struct {
+	lastInsertID int64
+	rowsAffected int64
+}
+
+func (r fakeInsertIgnoreResult) LastInsertId() (int64, error) { return r.lastInsertID, nil }
+func (r fakeInsertIgnoreResult) RowsAffected() (int64, error) { return r.rowsAffected, nil }
+
+type fakeInsertIgnoreDriver struct{}
+
+func (fakeInsertIgnoreDriver) Open(string) (driver.Conn, error) { return fakeInsertIgnoreConn{}, nil }
+
+type fakeInsertIgnoreConn struct{}
+
+func (fakeInsertIgnoreConn) Prepare(string) (driver.Stmt, error) { return fakeInsertIgnoreStmt{}, nil }
+func (fakeInsertIgnoreConn) Close() error                        { return nil }
+func (fakeInsertIgnoreConn) Begin() (driver.Tx, error)           { return fakeInsertIgnoreTx{}, nil }
+
+type fakeInsertIgnoreTx struct{}
+
+func (fakeInsertIgnoreTx) Commit() error   { return nil }
+func (fakeInsertIgnoreTx) Rollback() error { return nil }
+
+type fakeInsertIgnoreStmt struct{}
+
+func (fakeInsertIgnoreStmt) Close() error  { return nil }
+func (fakeInsertIgnoreStmt) NumInput() int { return -1 }
+func (fakeInsertIgnoreStmt) Exec([]driver.Value) (driver.Result, error) {
+	return fakeInsertIgnoreResult{
+		lastInsertID: fakeNextLastInsertID,
+		rowsAffected: fakeNextRowsAffected,
+	}, nil
+}
+func (fakeInsertIgnoreStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, errors.New("query not supported by fake driver")
+}
+
+func init() {
+	sql.Register(fakeInsertIgnoreDriverName, fakeInsertIgnoreDriver{})
+}
+
+func Test_InsertIgnore_ReturnsRowsAffectedForNonAutoIncrementPK(t *testing.T) {
+	err := Init(map[string]*Config{
+		"fake_insert_ignore": {Driver: fakeInsertIgnoreDriverName, DSN: "fake"},
+	})
+	assert.NoError(t, err)
+
+	m := New("event_log",
+		WithConn("fake_insert_ignore"),
+		WithPrimaryKey("id"),
+	)
+
+	// Case 1: a brand new row is inserted. On a non-auto-increment PK table
+	// LastInsertId is 0 even though the row was inserted, so the dedup gate
+	// (affected > 0) can only work if InsertIgnore reports RowsAffected.
+	fakeNextLastInsertID = 0
+	fakeNextRowsAffected = 1
+	affected, err := m.InsertIgnore(Record{"id": "abc", "name": "Alice"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), affected, "fresh insert on a non-auto-increment PK must report affected=1")
+
+	// Case 2: the row collides with the unique key and is silently ignored.
+	fakeNextLastInsertID = 0
+	fakeNextRowsAffected = 0
+	affected, err = m.InsertIgnore(Record{"id": "abc", "name": "Alice"})
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), affected, "ignored insert must report affected=0")
+}


### PR DESCRIPTION
## InsertIgnore 返回 RowsAffected 而非 LastInsertId

### 背景 / 原因

`xdb.Model.InsertIgnore` 此前返回 `LastInsertId` 作为"是否插入成功"的判定信号,这有两个问题:

1. **仅对自增主键有效**:当主键不是自增的(例如表用应用生成的 `xid` 字符串做主键),`LastInsertId` 恒为 0,无论行有没有真正插入。调用方常见的去重写法 `affected > 0` 因此完全失效,只能退回手拼 SQL、自己读 `RowsAffected`。
2. **在 Postgres 上直接崩溃**:`InsertIgnore` 没有像 `Insert`/`InsertBatch` 那样为 PG 加 `RETURNING` 分支,而是直接调 `result.LastInsertId()`;`lib/pq` 不支持该方法,会返回 error —— 也就是说这个方法在 PG 上实际每次调用都报错。

### 改动

- `InsertIgnore` 改为返回 `result.RowsAffected()`:**1 = 插入成功,0 = 因唯一键冲突被忽略**。对任意主键都成立,并与已有的 `InsertOrUpdate`(同样返回 `RowsAffected`)口径统一,同时顺带修复 PG 上的崩溃(`ON CONFLICT DO NOTHING` 配合 `RowsAffected`,无需 `RETURNING`)。
- 返回值由 `lastId` 改名为 `affected`,接口处补充语义注释。
- 修正一个复制粘贴 bug:`InsertIgnore` 内部的调试日志标签错写成了 `"InsertOrUpdate"`。
- 更新 `xdb/README.md` 示例与说明。
- 新增回归测试 `xdb/model_insert_ignore_test.go`。

### 结果

- 非自增主键(xid 等)表也能用 `InsertIgnore(...) ; affected > 0` 正确判定去重,下游不必再手拼 SQL。
- 修复 Postgres 上 `InsertIgnore` 报错的问题。
- `go build ./...`、`go vet ./xdb` 通过;新增测试通过(修复前能正确失败)。

### Review / 合并时需要注意

- **这是对公共 API 返回值的语义变更**(`LastInsertId` → `RowsAffected`)。如果上游别的仓库把它的返回值当作"新插入行的自增 id"使用,会受影响。不过旧值在"非自增主键"和"Postgres"两种场景下本就是 0 或直接报错,实际依赖它当 id 用的可能性很低;请帮忙确认没有其它仓库依赖旧语义。
- **测试取舍**:回归测试用了一个最小的 `database/sql` 假驱动来模拟"非自增主键、`LastInsertId=0` 但行已插入"的场景,**不依赖真实数据库、不引入新依赖**。没有用 SQLite,是因为 SQLite 每行都有隐式 `rowid`,`LastInsertId` 会返回非 0,反而无法复现此 bug。
- **本地未能跑完整 xdb 测试套件**:既有测试需要连真实 MySQL(`127.0.0.1:3306/fly_test`),CI/本地有 MySQL 的环境请补跑一遍 `go test ./xdb`。
