### PR TITLE
xdb: Add WhereRawArgs and WhereOrRawArgs functions for dynamic SQL co…

### DIFF
--- a/xdb/sql.go
+++ b/xdb/sql.go
@@ -111,6 +111,7 @@ type where struct {
 	logic    string
 	sub      []where
 	raw      string
+	rawArgs  []any
 }
 
 func WhereRaw(raw string) Option {
@@ -126,6 +127,31 @@ func WhereOrRaw(raw string) Option {
 		opts.where = append(opts.where, where{
 			raw:   raw,
 			logic: "or",
+		})
+	}
+}
+
+// WhereRawArgs 追加一个带 ? 占位符的 raw WHERE 片段。
+// raw 中每个 ? 按从左到右顺序消费 args 中的一个值，作为绑定参数下发
+// （driver 预处理占位符，非字符串拼接）。
+// 约定 raw 中 ? 的个数应等于 len(args)，由调用方保证；数量不匹配时由 driver 在执行阶段报错。
+// WhereRaw(raw) 等价于 WhereRawArgs(raw) 无参数。
+func WhereRawArgs(raw string, args ...any) Option {
+	return func(opts *Options) {
+		opts.where = append(opts.where, where{
+			raw:     raw,
+			rawArgs: args,
+		})
+	}
+}
+
+// WhereOrRawArgs 是 WhereRawArgs 的 OR 逻辑变体。
+func WhereOrRawArgs(raw string, args ...any) Option {
+	return func(opts *Options) {
+		opts.where = append(opts.where, where{
+			raw:     raw,
+			rawArgs: args,
+			logic:   "or",
 		})
 	}
 }
@@ -486,6 +512,7 @@ func whereBuilder(condition []where) (sql string, args []any) {
 
 		if v.raw != "" {
 			tokens = append(tokens, v.raw)
+			args = append(args, v.rawArgs...)
 			continue
 		}
 

--- a/xdb/sql_raw_args_test.go
+++ b/xdb/sql_raw_args_test.go
@@ -1,0 +1,81 @@
+package xdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhereRawArgs_MixedWithWhereEq(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("todos"),
+		WhereEq("type", "todo"),
+		WhereRawArgs("attributes->>'$.channel_subject_type' = ?", "user"),
+		WhereRawArgs("attributes->>'$.channel_subject_id' = ?", "42"),
+	)
+	assert.Equal(t,
+		"select * from todos where type = ? and attributes->>'$.channel_subject_type' = ? and attributes->>'$.channel_subject_id' = ?",
+		sql)
+	assert.Equal(t, []any{"todo", "user", "42"}, args)
+}
+
+func TestWhereRawArgs_MultiPlaceholder(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("todos"),
+		WhereRawArgs("coalesce(retry_at, ?) <= ?", "fallback", "deadline"),
+	)
+	assert.Equal(t, "select * from todos where coalesce(retry_at, ?) <= ?", sql)
+	assert.Equal(t, []any{"fallback", "deadline"}, args)
+}
+
+func TestWhereOrRawArgs_UsesOrLogic(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("t"),
+		WhereEq("a", 1),
+		WhereOrRawArgs("b = ?", 2),
+	)
+	assert.Equal(t, "select * from t where a = ? or b = ?", sql)
+	assert.Equal(t, []any{1, 2}, args)
+}
+
+func TestWhereRawArgs_InsideWhereGroup(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("t"),
+		WhereEq("a", 1),
+		WhereGroup(
+			WhereRawArgs("json_contains(tags, ?)", "x"),
+			WhereOrEq("b", 2),
+		),
+	)
+	assert.Equal(t, "select * from t where a = ? and (json_contains(tags, ?) or b = ?)", sql)
+	assert.Equal(t, []any{1, "x", 2}, args)
+}
+
+func TestWhereRawArgs_InUpdateAndDelete(t *testing.T) {
+	usql, uargs := UpdateBuilder(
+		table("t"),
+		Field("status"),
+		Value("done"),
+		WhereRawArgs("attributes->>'$.k' = ?", "v"),
+	)
+	assert.Equal(t, "update t set status = ? where attributes->>'$.k' = ?", usql)
+	assert.Equal(t, []any{"done", "v"}, uargs)
+
+	dsql, dargs := DeleteBuilder(
+		table("t"),
+		WhereRawArgs("attributes->>'$.k' = ?", "v"),
+	)
+	assert.Equal(t, "delete from t where attributes->>'$.k' = ?", dsql)
+	assert.Equal(t, []any{"v"}, dargs)
+}
+
+// WhereRaw 旧行为不变：raw 片段原样进入，不绑定任何参数。
+func TestWhereRaw_BackwardCompat(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("t"),
+		WhereEq("a", 1),
+		WhereRaw("b is null"),
+	)
+	assert.Equal(t, "select * from t where a = ? and b is null", sql)
+	assert.Equal(t, []any{1}, args)
+}


### PR DESCRIPTION
## 1. 现状核实（已在本仓库实跑验证）

本仓库 `xdb` **不对标识符做任何转义**（`whereBuilder` 默认分支为 `fmt.Sprintf("%s %s ?", field, operator)`，无反引号/引号）。由此推出两个事实：

1. **`Where(field, op, value)` 可以把"表达式"当 field 传**，field 原样进 SQL，value 走绑定。实跑：

   ```text
   Where("attributes->>'$.channel_subject_type'", "=", "user")
   → where attributes->>'$.channel_subject_type' = ?   ARGS=[user]
   ```

2. **`WhereRaw(raw)` 完全不碰 args**（`whereBuilder` 的 raw 分支 `tokens = append(tokens, v.raw); continue`，不向 `args` 追加）。所以**带 `?` 的 raw 片段无法安全绑参**——这是真实空白，值只能字符串内插，存在注入面。实跑：

   ```text
   WhereRaw("attributes->>'$.channel_subject_id' = 'injected'")
   → where attributes->>'$.channel_subject_id' = 'injected'   ARGS=[]   // 值没进绑定
   ```

---

## 3. 能力边界：现有 `Where*` 已覆盖什么，本需求补什么

现有 `Where*` 家族都把传入的 field 原样插入、值走绑定，因此**只要表达式落在下列固定形状里，今天就能做**（field 位置可传任意表达式）：

| 现有 API | 生成形状 | 占位符布局 |
|---|---|---|
| `Where` / `WhereEq` / `WhereGt` … | `expr op ?` | 单个、末尾 |
| `WhereIn` / `WhereNotIn` | `expr in (?, ?, …)` | 多个、列表 |
| `WhereBetween` | `expr between ? and ?` | 两个、固定 |
| `WhereFindInSet` | `find_in_set(?, expr)` | 单个、**函数内/非末尾** |
| `WhereLike` | `expr like ?` | 单个、末尾 |

> 实跑佐证（表达式当 field 同样成立）：
> ```text
> WhereBetween("attributes->>'$.score'", 1, 10)  → ... between ? and ?            ARGS=[1 10]
> WhereFindInSet("attributes->>'$.tags'", "x")    → find_in_set(?, attributes->>'$.tags')  ARGS=[x]
> ```

**`WhereRawArgs` 的唯一增量价值 = 上述固定形状之外的占位符布局**：任意个数、任意位置的 `?`，且无法拆成 `LHS op ?` / `between` / `in` / `find_in_set` / `like` 这几种。例如：

```go
xdb.WhereRawArgs("JSON_CONTAINS(attributes->'$.tags', ?)", tagJSON)        // 函数内单占位符，非 find_in_set 形状
xdb.WhereRawArgs("COALESCE(retry_at, ?) <= ?", fallback, deadline)         // 两个占位符（一个在函数内、一个在末尾）
xdb.WhereRawArgs("ST_Distance(loc, POINT(?, ?)) < ?", lng, lat, radius)    // 三个占位符
xdb.WhereRawArgs("MATCH(title, body) AGAINST (? IN BOOLEAN MODE)", kw)     // 特殊语法
```

> ⚠️ 反例（**不要**用这些来论证需求，它们用现有 API 就能做）：
> - `COALESCE(retry_at, created_at) <= ?` → `Where("COALESCE(retry_at, created_at)", "<=", d)`
> - `CAST(... AS CHAR(64)) = ?` → `Where("CAST(...)", "=", v)`
> - `attributes->>'$.score' BETWEEN ? AND ?` → `WhereBetween("attributes->>'$.score'", lo, hi)`

---

## 4. 为什么仍要加（动机，按重要性排序）

1. **（首要）一旦 xdb 日后给 `Where`/`WhereEq` 加上标识符转义（合理的安全/正确性加固），所有"把表达式塞进 field"的写法都会被**悄悄引坏**。显式的 `WhereRawArgs` 声明"这是 raw 表达式 + 绑定参数"，**不依赖**是否转义，是面向未来的正确 API。
2. **（次要）补齐占位符布局。** 现有 `Where*` 只覆盖 §3 表格里那几种固定形状；任意个数/位置的 `?`（§3 正例）目前无 API 可表达，而 `WhereRaw` 又不能绑参。
3. **消除注入面。** 在没有 `WhereRawArgs` 之前，遇到 §3 正例那种形状，开发者只能退回 `WhereRaw` + 字符串内插，引入注入风险。

---

## 5. API

```go
// WhereRawArgs 追加一个带 ? 占位符的 raw WHERE 片段。
// raw 中每个 ? 按从左到右顺序消费 args 中的一个值，作为绑定参数下发（driver 预处理占位符，非字符串拼接）。
func WhereRawArgs(raw string, args ...any) Option

// OR 逻辑变体（与 WhereOrRaw 对应）。
func WhereOrRawArgs(raw string, args ...any) Option
```

---

## 6. 行为要求

1. **片段原样拼接**：`raw` 像现有 `WhereRaw` 一样原样进入 WHERE（默认与其它条件 `AND` 连接；Or 变体用 `OR`），不解析、不加引号。
2. **参数真绑定**：`raw` 里每个 `?` 按顺序绑定 `args` 里对应的值，作为 SQL 预处理参数下发——**不得 `fmt.Sprintf` 进 SQL 字符串**。
3. **混用顺序正确**：可与 `WhereEq` / `WhereIn` / `WhereGroup` 等任意混用、任意顺序；最终生成的 WHERE 里，各条件的占位符与绑定参数列表必须**按条件出现的先后顺序对齐**（即 `WhereRawArgs` 的 args 插在该片段在 WHERE 中所处的位置）。
4. **适用范围**：与现有 `Where*` 一致——`Selects` / `First` / `Count` / `Update` / `Delete`，以及 `WhereGroup` / `WhereOr` 组合内均可用。
5. **向后兼容**：不改 `WhereRaw(raw)` 行为（它等价于 `WhereRawArgs(raw)` 无参数）。
6. **占位符与参数数量**：约定 `raw` 中 `?` 个数 == `len(args)`；数量不匹配时的行为请在实现里明确（建议：不校验，由调用方保证——与现有 `WhereBetween`/`WhereIn` 一致，由 driver 在 exec 阶段报错；或 panic/返回错误，二选一并写进注释）。

---

## 8. 验收标准

1. `WhereEq` 与 `WhereRawArgs` 混用时，所有值都作为绑定参数、顺序正确（断言生成的 SQL + args，或真连 DB round-trip 验证）。
2. **多占位符 / 非末尾占位符**的片段（如 `COALESCE(x, ?) <= ?`、`JSON_CONTAINS(col, ?)`）绑定正确、顺序对齐。
3. 含特殊字符（引号、`'` 等）的值能安全绑定，**调用方无需手动转义、无注入**。
4. 在事务内、以及与其它 `Where*` / `WhereGroup` 组合时行为一致。
5. Postgres 下 `?`→`$n` 转换后参数顺序正确。
6. `WhereRaw` 旧行为不变。