### PR TITLE
xdb: support args in raw order by expressions

### DIFF
--- a/xdb/README.md
+++ b/xdb/README.md
@@ -248,6 +248,13 @@ xdb.WhereFindInSet("tags", "golang")
 xdb.OrderByDesc("created_at")
 xdb.OrderByAsc("id")
 
+// 带绑定参数的原始排序表达式
+xdb.OrderByRaw(
+    "MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE) DESC",
+    keyword,
+)
+// 原始 SQL 表达式必须由应用代码控制；动态值通过参数绑定传入。
+
 // 分页
 xdb.Limit(10)
 xdb.Offset(20)

--- a/xdb/sql.go
+++ b/xdb/sql.go
@@ -12,12 +12,17 @@ const deleteMod = "delete from %s"
 
 type Option = func(opts *Options)
 
+type sqlFragment struct {
+	sql  string
+	args []any
+}
+
 type Options struct {
 	database  string
 	table     string
 	field     []string
 	where     []where
-	orderBy   []string
+	orderBy   []sqlFragment
 	groupBy   string
 	limit     int
 	offset    int
@@ -480,14 +485,35 @@ func WhereOrFindInSet(field string, value any) Option {
 
 func OrderByDesc(field string) Option {
 	return func(opts *Options) {
-		opts.orderBy = append(opts.orderBy, field+" desc")
+		opts.orderBy = append(opts.orderBy, sqlFragment{sql: field + " desc"})
 	}
 }
 
 func OrderByAsc(field string) Option {
 	return func(opts *Options) {
-		opts.orderBy = append(opts.orderBy, field+" asc")
+		opts.orderBy = append(opts.orderBy, sqlFragment{sql: field + " asc"})
 	}
+}
+
+// OrderByRaw appends a raw ORDER BY expression with bound arguments.
+// raw must be trusted application SQL; dynamic values belong in args.
+// Placeholder mismatches are reported by the database driver at execution time.
+func OrderByRaw(raw string, args ...any) Option {
+	return func(opts *Options) {
+		opts.orderBy = append(opts.orderBy, sqlFragment{
+			sql:  raw,
+			args: args,
+		})
+	}
+}
+
+func orderByBuilder(orderBy []sqlFragment) (sql string, args []any) {
+	expressions := make([]string, 0, len(orderBy))
+	for _, fragment := range orderBy {
+		expressions = append(expressions, fragment.sql)
+		args = append(args, fragment.args...)
+	}
+	return strings.Join(expressions, ", "), args
 }
 
 func GroupBy(field string) Option {
@@ -573,7 +599,9 @@ func SelectBuilder(opts ...Option) (sql string, args []any) {
 	}
 
 	if len(_opts.orderBy) > 0 {
-		sql = sql + " order by " + strings.Join(_opts.orderBy, ", ")
+		_orderBy, _args := orderByBuilder(_opts.orderBy)
+		sql = sql + " order by " + _orderBy
+		args = append(args, _args...)
 	}
 
 	if _opts.limit != 0 {

--- a/xdb/sql_order_by_raw_test.go
+++ b/xdb/sql_order_by_raw_test.go
@@ -1,0 +1,109 @@
+package xdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderByRawArgsFollowSQLClauseOrder(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("dough"),
+		OrderByRaw("MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE) DESC", "keyword"),
+		WhereEq("type", "bread"),
+		WhereEq("tenant_id", int64(42)),
+		WhereIn("status", []any{"ready", "draft"}),
+		WhereEq("is_deleted", 0),
+		Limit(20),
+	)
+
+	assert.Equal(t,
+		"select * from dough where type = ? and tenant_id = ? and status in (?,?) and is_deleted = ? order by MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE) DESC limit ? offset ?",
+		sql,
+	)
+	assert.Equal(t, []any{"bread", int64(42), "ready", "draft", 0, "keyword", 20, 0}, args)
+}
+
+func TestOrderByRawPreservesExpressionAndArgumentOrder(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("dough"),
+		WhereRawArgs("MATCH(title) AGAINST(?)", "where-keyword"),
+		OrderByAsc("priority"),
+		OrderByRaw("FIELD(status, ?, ?)", "ready", "draft"),
+		OrderByRaw("CASE WHEN tenant_id = ? THEN 0 ELSE 1 END", int64(42)),
+		OrderByDesc("id"),
+	)
+
+	assert.Equal(t,
+		"select * from dough where MATCH(title) AGAINST(?) order by priority asc, FIELD(status, ?, ?), CASE WHEN tenant_id = ? THEN 0 ELSE 1 END, id desc",
+		sql,
+	)
+	assert.Equal(t, []any{"where-keyword", "ready", "draft", int64(42)}, args)
+}
+
+func TestOrderByRawSupportsExpressionWithoutArguments(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("dough"),
+		OrderByRaw("RAND()"),
+	)
+
+	assert.Equal(t, "select * from dough order by RAND()", sql)
+	assert.Empty(t, args)
+}
+
+func TestOrderByExistingOptionsRemainCompatible(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("dough"),
+		OrderByAsc("priority"),
+		OrderByDesc("id"),
+	)
+
+	assert.Equal(t, "select * from dough order by priority asc, id desc", sql)
+	assert.Empty(t, args)
+}
+
+func TestOrderByRawPostgreSQLPlaceholderOrder(t *testing.T) {
+	sql, args := SelectBuilder(
+		table("dough"),
+		OrderByRaw("CASE WHEN tenant_id = ? THEN ? ELSE ? END DESC", int64(42), 1, 0),
+		WhereEq("type", "bread"),
+		Limit(10),
+	)
+
+	sql = GetDialect("postgres").ConvertPlaceholders(sql)
+
+	assert.Equal(t,
+		"select * from dough where type = $1 order by CASE WHEN tenant_id = $2 THEN $3 ELSE $4 END DESC limit $5 offset $6",
+		sql,
+	)
+	assert.Equal(t, []any{"bread", int64(42), 1, 0, 10, 0}, args)
+}
+
+func TestOrderByRawArgumentsDoNotLeakIntoMutationBuilders(t *testing.T) {
+	insertSQL, insertArgs := InsertBuilder(
+		table("dough"),
+		Field("name"),
+		Value("baguette"),
+		OrderByRaw("FIELD(status, ?)", "ready"),
+	)
+	assert.Equal(t, "insert into dough (name) values (?)", insertSQL)
+	assert.Equal(t, []any{"baguette"}, insertArgs)
+
+	updateSQL, updateArgs := UpdateBuilder(
+		table("dough"),
+		Field("status"),
+		Value("done"),
+		WhereEq("id", 1),
+		OrderByRaw("FIELD(status, ?)", "ready"),
+	)
+	assert.Equal(t, "update dough set status = ? where id = ?", updateSQL)
+	assert.Equal(t, []any{"done", 1}, updateArgs)
+
+	deleteSQL, deleteArgs := DeleteBuilder(
+		table("dough"),
+		WhereEq("id", 1),
+		OrderByRaw("FIELD(status, ?)", "ready"),
+	)
+	assert.Equal(t, "delete from dough where id = ?", deleteSQL)
+	assert.Equal(t, []any{1}, deleteArgs)
+}


### PR DESCRIPTION
## 背景

这个 PR 为 `xdb` 的 Option/builder 增加了带参数的原始排序能力：

```go
xdb.OrderByRaw(raw string, args ...any)
```

主要解决 MySQL FULLTEXT 全文检索无法完整复用现有 builder 的问题。

使用 MySQL FULLTEXT 索引进行自然语言检索时，通常需要通过下面的表达式计算匹配结果和相关性分数：

```sql
MATCH(title, description, summary)
AGAINST(? IN NATURAL LANGUAGE MODE)
```

同一个表达式一般会同时用于：

1. `WHERE`：过滤没有命中全文索引的记录；
2. `ORDER BY`：按照 FULLTEXT 相关性分数从高到低排序。

例如：

```sql
SELECT *
FROM dough
WHERE type = ?
  AND tenant_id = ?
  AND status IN (?, ?)
  AND is_deleted = ?
  AND MATCH(title, description, summary)
      AGAINST(? IN NATURAL LANGUAGE MODE)
ORDER BY MATCH(title, description, summary)
         AGAINST(? IN NATURAL LANGUAGE MODE) DESC
LIMIT ? OFFSET ?
```

这里 `WHERE` 和 `ORDER BY` 中的两个 `MATCH ... AGAINST(?)` 都需要绑定检索关键词。

## 原有问题

`xdb` 已经可以通过 `WhereRawArgs` 在原始 WHERE 条件中绑定参数：

```go
xdb.WhereRawArgs(
    "MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE)",
    keyword,
)
```

但原有排序 Option 只有：

```go
xdb.OrderByAsc(field)
xdb.OrderByDesc(field)
```

它们只能生成排序字符串，无法为排序表达式附带参数。

虽然可以把 `MATCH ... AGAINST(?)` 直接传给 `OrderByDesc`，但 builder 没有地方接收对应的 `keyword` 参数，最终会出现 SQL 中存在占位符、args 中却缺少对应参数的问题。

调用方只能选择：

- 把关键词直接拼进 SQL，带来 SQL 注入和转义风险；
- 或者放弃 builder，手写整条 SQL。

后一种方式会导致原本已经由 builder 处理的 `type`、`tenant_id`、`status IN (...)`、软删除条件、Limit/Offset 等逻辑也需要重复实现，增加维护成本。

这个问题也不只存在于 FULLTEXT 场景。几何距离排序、带参数的 CASE 排序等计算表达式也有相同需求。

## 本次改动

新增：

```go
func OrderByRaw(raw string, args ...any) Option
```

FULLTEXT 查询现在可以完整使用 Option/builder 构造：

```go
records, err := model.Selects(
    xdb.WhereEq("type", doughType),
    xdb.WhereEq("tenant_id", tenantID),
    xdb.WhereIn("status", []any{"ready", "published"}),
    xdb.WhereEq("is_deleted", 0),
    xdb.WhereRawArgs(
        "MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE)",
        keyword,
    ),
    xdb.OrderByRaw(
        "MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE) DESC",
        keyword,
    ),
    xdb.Limit(20),
)
```

调用方只需要追加全文检索相关的 WHERE 和 ORDER BY Option，其余过滤、分页和软删除逻辑仍然由现有 builder 统一处理。

`OrderByRaw` 也支持多个参数，例如：

```go
xdb.OrderByRaw(
    "CASE WHEN tenant_id = ? THEN ? ELSE ? END DESC",
    tenantID,
    1,
    0,
)
```

不带参数的原始排序表达式同样支持：

```go
xdb.OrderByRaw("RAND()")
```

## 参数顺序处理

本次改动的重点不是简单拼接 ORDER BY 字符串，而是保证 SQL 占位符和 args 严格对齐。

ORDER BY 表达式现在会和自身参数一起保存。`SelectBuilder` 最终按照 SQL 子句出现顺序组装参数：

```text
WHERE args
→ ORDER BY args
→ LIMIT/OFFSET args
```

例如上面的 FULLTEXT 查询会产生类似下面的参数顺序：

```text
[
    doughType,
    tenantID,
    "ready",
    "published",
    0,
    keyword, // WHERE MATCH ... AGAINST(?)
    keyword, // ORDER BY MATCH ... AGAINST(?)
    20,
    0,
]
```

即使调用方在 Go 代码中先传入 `OrderByRaw`、后传入 WHERE Option，args 仍然会按照最终 SQL 中 `WHERE → ORDER BY → LIMIT` 的顺序排列，而不是按照 Option 的调用顺序排列。

这也保证 PostgreSQL 方言在将 `?` 转换成 `$1`、`$2` 等占位符时，编号与 args 保持一致。虽然 `MATCH ... AGAINST` 本身是 MySQL 语法，但 `OrderByRaw` 的参数管理能力是通用的。

## 兼容性

为了尽量降低对现有 builder 的影响，本次只调整了 ORDER BY 的内部表示，没有修改 SELECT 字段相关逻辑。

以下能力均保持原样：

- `Field`
- `FieldRaw`
- `AggregateSum`
- `AggregateCount`
- `AggregateMax`
- `OrderByAsc`
- `OrderByDesc`
- `WhereRawArgs`
- InsertBuilder
- UpdateBuilder
- DeleteBuilder
- hasOne/hasMany 关联数据加载

现有 `OrderByAsc` 和 `OrderByDesc` 生成的 SQL 保持不变。

`OrderByRaw` 中的参数只会在 `SelectBuilder` 生成 ORDER BY 子句时加入查询参数，不会泄漏到 Insert、Update 或 Delete 的 args 中。

本次没有增加带参数的 SELECT 计算列能力。`SelectRaw` 属于次要需求，暂时推迟，避免修改目前被 SELECT、INSERT 和 UPDATE 共用的 `Options.field` 结构。

## 安全说明

`OrderByRaw` 的原始 SQL 表达式必须由应用代码控制，不能直接使用用户输入构造。

动态值应始终通过 `args` 绑定：

```go
// 推荐
xdb.OrderByRaw(
    "MATCH(title,description,summary) AGAINST(? IN NATURAL LANGUAGE MODE) DESC",
    keyword,
)
```

不要把检索词直接拼接到 SQL 表达式中。

与 `WhereRawArgs` 一致，raw 中占位符数量与 args 数量不匹配时，由数据库 driver 在执行阶段返回错误。

## 测试覆盖

本次新增的数据库无关 Builder 测试覆盖了：

- FULLTEXT `MATCH ... AGAINST(?)` 与结构化 WHERE、IN、Limit 的组合；
- Option 调用顺序和最终 SQL 子句顺序不一致时的 args 排列；
- `WhereRawArgs` 与 `OrderByRaw` 同时使用；
- 单个原始排序表达式包含多个占位符；
- 多个普通和原始 ORDER BY 表达式混合；
- 不带参数的原始排序表达式；
- 原有 `OrderByAsc`、`OrderByDesc` SQL 兼容性；
- PostgreSQL `$1...$n` 占位符顺序；
- ORDER BY 参数不会进入 Insert、Update、Delete。